### PR TITLE
Switch hillshading layer to HTTPS

### DIFF
--- a/js/fsmap.js
+++ b/js/fsmap.js
@@ -151,7 +151,7 @@ var bingAerial = new L.TileLayer.QuadKeyTileLayer(
 );
 
 var hillshading = new L.TileLayer(
-    'http://{s}.tiles.wmflabs.org/hillshading/{z}/{x}/{y}.png',
+    'https://tiles.wmflabs.org/hillshading/{z}/{x}/{y}.png',
     {
         attribution: "Hillshading by ??? from NASA SRTM data",
         minZoom: 3,


### PR DESCRIPTION
The subdomains a.tile. etc. are not covered by the SSL certificate, but using tile.wmflabs.org seems to work correctly.